### PR TITLE
Updated with complete list of Divination Cards (excluding new Crucible cards)

### DIFF
--- a/bonusItemInfo.json
+++ b/bonusItemInfo.json
@@ -671,296 +671,1266 @@
 		},
 		"DivinationCard": {
 			"items": {
-				"A Dab of Ink": {
-					"text": "Found in Academy, Museum, Scriptorium, The library"
-				},			
-				"A Dusty Memory": {
-					"text": "Found in Altered Distant Memory, Augmented Distant Memory, Cortex, Rewritten Distant Memory, Twisted Distant Memory"
-				},
-
-				"A Familiar Call": {
-					"text": "Drops from Guardian of the Chimera."
-				},
-				
-				"A Fate Worse Than Death": {
-					"text": "Drops from Conquerors and Sirus."
-				},
-
-				"A Modest Request": {
-					"text": "Drops from Eater of Souls, Nightmare's Omen, The Hallowed Husk, The High Templar"
-				},
-
-				"A Mother's Parting Gift": {
-					"text": "Found in The High Gardens, The Imperial Gardens"
-				},
-
-				"A Note in the Wind": {
-					"text": "Found in Desert, Desert Spring, Dry Sea, Dunes, The Oasis."
-				},
-
-				"A Sea of Blue": {
-					"text": "Found in Crystal Ore, Grotto, Mineral Pools, Primordial Blocks." 
-				},
-
-				"A Stone Perfected": {
-					"text": "Found in Coves, Flooded Mine, Grotto, Peninsula, Vault, Waterways, Wharf."
-				},
-
-				"Abandoned Wealth": {
-					"text": "Found in Mao Kun."
-				},
-
-				"Acclimatisation": {
-					"text": "Found in Desert, Desert Spring, Dry Sea, Dunes."
-				},
-
-				"Akil's Prophecy": {
-					"text": "Found in The Temple of Atzoatl."
-				},
-
-				"Alivia's Grace": {
-					"text": "Found in Ashen Wood, Bramble Valley, Dark Forest, Forbidden Woods, Jungle Valley, Lair, Ramparts, Spider Forest, Stagnation, Thicket, Tropical Island."
-				},
-
-				"Alluring Bounty": {
-					"text": "Found in The Alluring Abyss, The Apex of Sacrifice"
-				},
-
-				"Alone in the Darkness": {
-					"text": "Drops from an Abyssal Trove."
-				},
-
-				"Altered Perception": {
-					"text": "Drops from Uhtred Covetous Traitor."
-				},
-
-				"Ambitious Obsession": {
-					"text": "Drops from map bosses, Cold River, Sunken City, Fields, Cemetery, Infested Valley, Summit, Reef, Siege, Terrace."
-				},
-
-				"Anachary's Price": {
-					"text": "Drops from Rogue Exiles."
-				},
-
-				"Arrogance of The Vaal": {
-					"text": "Found in Ancient City, Sunken City, Vaal Pyramid."
-				},
-
-				"Assassin's Favour": {
-					"text": "Found in Alleyways, Arcade, Bazaar, Port, The Marketplace, The Quay."
-				},
-
-				"Astral Protection": {
-					"text": "Found in The Moon Temple."
-				},
-
-				"Atziri's Arsenal": {
-					"text": "Found in the Vaults of Atziri."
-				}, 
-
-				"Audacity": {
-					"text": "Found in The Apex of Sacrifice."
-				},
-
-				"Auspicious Ambitions": {
-					"text": "Drops from The Eater of Worlds, The Elder, The Maven, The Searing Exach."
-				},
-
-				"Azure Rage": {
-					"text": "Found in Factory." 
-				}, 
-
-				"Azyran's Reward": {
-					"text": "Found in Laboratory, Relic Chambers, Stagnation."
-				},
-
-				"Baited Expectations": {
-					"text": "Found in Desert, Desert Spring, Dry Sea, Dunes."
-				},
-
-				"Beauty Through Death": {
-					"text": "Drops from Vaal Temple Bosses."
-				},
-
-				"Bijoux": {
-					"text": "Found in Crystal Ore, Dig, Excavation, Flooded Mine, Grotto."
-				},
-
-				"Blind Venture": {
-					"text": "Found in Museum, Relic Chambers, The Reliquary."
-				},
-
-				"Boon of Justice": {
-					"text": "Found in Chateau, Conservatory, Orchard, Plaza."
-				},
-
-				"Boon of the First Ones": {
-					"text": "Found in Pit of the Chimera."
-				},
-
-				"Boundless Realms": {
-					"text": "Found in Cold River, Temple, The Harbour Bridge, The Solaris Temple, The Twilight Temple."
-				},
-
-				"Bowyer's Dream": {
-					"text": "Drops from Lord of the Ashen Arrow, Mirage of Bones, Steelpoint the Avenger, Stonebeak Battle Fowl."
-				},
-
-				"Broken Promises": {
-					"text": "Drops from Mausoleum boss."
-				},
-
-				"Broken Truce": {
-					"text": "Drops from Jorgin (Jun)."
-				}, 
-
-				"Brother's Stash": {
-					"text": "Found in Cemetary, Grave Trough, Graveyard."
-				},
-
-				"Brother's in Exile": {
-					"text": "Found in Chateau, Orchard, Plaza."
-				},
-
-				"Brush, Paint and Palette": {
-					"text": "Drops from Sepulchre Boss."
-				},
-
-				"Buried Treasure": {
-					"text": "Found in Crystal Ore, Dig, Excavation, Flooded Mine, Geode, Grotto."
-				},
-
-				"Burning Blood": {
-					"text": "Found in Forge of the Phoenix, Lava Chamber."
-				},
-
-				"Call to the First Ones": {
-					"text": "Found in Bramble Valley, Dark Forest, Forbidden Woods, The Northern Forest, Thicket."
-				},
-
-				"Cameria's Cut": {
-					"text": "Drops from Cameria (Jun)."
-				},
-
-				"Cartographer's Delight": {
-					"text": "Found in The Foothills, The Harbour Bridge."
-				},
-
-				"Chaotic Disposition": {
-					"text": "Found in Poorjoy's Asylum."
-				}, 
-
-				"Chasing Risk": {
-					"text": "Drops from The Vaal Omnitect (Alva Temple)."
-				},
-
-				"Checkmate": {
-					"text": "Found in Academy, Museum."
-				},
-
-				"Choking Guilt": {
-					"text": "Drops from The Infinite Hunger."
-				},
-
-				"Costly Curio": {
-					"text": "Found in Museum, Relic Chamber."
-				},
-
-				"Council of Cats": {
-					"text": "Drops from Al-Hezmin The Hunter."
-				},
-
-				"Coveted Possession": {
-					"text": "Found in Bone Crypt, The Catacombs, The Ossuary."
-				},
-
-				"Cursed Words": {
-					"text": "Found in Cemetary, Grave Trough, Graveyard."
-				},
-
-				"Dark Dreams": {
-					"text": "Drops from Minara Anemina (Rogue exile)."
-				},
-
-				"Dark Temptation": {
-					"text": "Found in hidden chests (Azurite Mine)."
-				},
-
-				"Darker Half": {
-					"text": "Found in maps affected by Delirium and Simulacrum."
-				},
-
-				"Deadly Joy": {
-					"text": "Found in Poorjoy's Asylum."
-				},
-
-				"Death": {
-					"text": "Found in Bog, Marshes, Mud Geyser, The Karui Fortress."
-				},
-
-				"Deathly Designs": {
-					"text": "Drops from Ash Lessard (Rogue Exile)."
-				},
-
-				"Dementophobia": {
-					"text": "Drops from Conquerors and Cortex."
-				},
-				
-				"Demigod's Wager": {
-					"text": "Drops from Basilica Boss and The Cleansing Light."
-				},
-
-				"Desecrated Virtue": {
-					"text": "Drops from Aul (Delve Boss)."
-				}, 
-
-				"Desperate Crusade": {
-					"text": "Found in Basilica, Residence."
-				},
-
-				"Destined to Crumble": {
-					"text": "Found in Academy, Museum, Scriptorium."
-				},
-
-				"Dialla's Subjugation": {
-					"text": "Found in Cold River, Temple, The Solaris/Twilight Temple."
-				},
-
-				"Disdain": {
-					"text": "Found in The Maven's Crucible."
-				},
-
-				"Divine Beauty": {
-					"text": "Drops from map bosses, Lava Chamber, Underground Sea(Maelstrom of Chaos), Mineral Pools."
-				},
-
-				"Divine Justice": {
-					"text": "Drops from an Armourer's Strongbox."
-				},
-				
-				"Doedre's Madness": {
-					"text": "Drops from Doedre and similar boss models."
-				},
-
-				"Doryani's Epiphany": {
-					"text": "Unconfirmed, Prohibited Library."
-				},
-
-				"Draped in Dreams" : {
-					"text": "Unconfirmed"
-				},
-
-				"Duality": {
-					"text": "Drops from Architects (Alva Temple)."
-				},
-
-				"Dying Anguish": {
-					"text": "Found in Arsenal, Colonade, Ghetto, Port, Precinct, Promenade."
-				},
-
-				"Dying Light" : {
-					"text": "Drops from The Shaper."
-				}
+                "A Dab of Ink": {
+                    "text": "Found in Academy, Museum, Scriptorium, The Library"
+                },
+                "A Dusty Memory": {
+                    "text": "Found in Altered Distant Memory, Augmented Distant Memory, Cortex, Rewritten Distant Memory, Twisted Distant Memory"
+                },
+                "A Familiar Call": {
+                    "text": "Dropped by Guardian of the Chimera."
+                },
+                "A Fate Worse Than Death": {
+                    "text": "Dropped by Conquerors and Sirus Awakener of Worlds."
+                },
+                "A Modest Request": {
+                    "text": "Dropped by Eater of Souls, Nightmare's Omen, The Hallowed Husk, The High Templar."
+                },
+                "A Mother's Parting Gift": {
+                    "text": "Found in The High Gardens, The Imperial Gardens."
+                },
+                "A Note in the Wind": {
+                    "text": "Found in Desert, Desert Spring, Dry Sea, Dunes, The Oasis."
+                },
+                "A Sea of Blue": {
+                    "text": "Found in Crystal Ore, Grotto, Mineral Pools, Primordial Blocks."
+                },
+                "A Stone Perfected": {
+                    "text": "Found in Coves, Flooded Mine, Grotto, Peninsula, Vault, Waterways, Wharf."
+                },
+                "Abandoned Wealth": {
+                    "text": "Found in Mao Kun."
+                },
+                "Acclimatisation": {
+                    "text": "Found in Desert, Desert Spring, Dry Sea, Dunes."
+                },
+                "Akil's Prophecy": {
+                    "text": "Found in The Temple of Atzoatl."
+                },
+                "Alivia's Grace": {
+                    "text": "Found in Ashen Wood, Bramble Valley, Dark Forest, Forbidden Woods, Jungle Valley, Lair, Ramparts, Spider Forest, Stagnation, Thicket, Tropical Island."
+                },
+                "Alluring Bounty": {
+                    "text": "Found in The Alluring Abyss, The Apex of Sacrifice."
+                },
+                "Alone in the Darkness": {
+                    "text": "Dropped by an Abyssal Trove."
+                },
+                "Altered Perception": {
+                    "text": "Dropped by Uhtred, Covetous Traitor (Order of the Chalice Expedition Logbook areas 75+)."
+                },
+                "Ambitious Obsession": {
+                    "text": "Dropped by map boss, Cold River, Sunken City, Fields, Cemetary, Infested Valley, Summit, Reef, Siege, Terrace."
+                },
+                "Anarchy's Price": {
+                    "text": "Dropped by Rogue Exiles."
+                },
+                "Arrogance of the Vaal": {
+                    "text": "Found in Ancient City, Sunken City, Vaal Pyramid."
+                },
+                "Assassin's Favour": {
+                    "text": "Found in Alleyways, Arcade, Bazaar, Port, The Marketplace, The Quay."
+                },
+                "Astral Protection": {
+                    "text": "Found in Moon Temple."
+                },
+                "Atziri's Arsenal": {
+                    "text": "Found in Vaults of Atziri."
+                },
+                "Audacity": {
+                    "text": "Found in The Apex of Sacrifice."
+                },
+                "Auspicious Ambitions": {
+                    "text": "Dropped by The Eater of Worlds, The Elder, The Maven, The Searing Exarch."
+                },
+                "Azure Rage": {
+                    "text": "Found in Factory."
+                },
+                "Azyran's Reward": {
+                    "text": "Found in Laboratory, Relic Chambers, Stagnation."
+                },
+                "Baited Expectations": {
+                    "text": "Found in Desert, Desert Spring, Dry Sea, Dunes."
+                },
+                "Beauty Through Death": {
+                    "text": "Dropped by map boss, Vaal Temple."
+                },
+                "Bijoux": {
+                    "text": "Found in Crystal Ore, Dig, Excavation, Flooded Mine, Grotto."
+                },
+                "Blind Venture": {
+                    "text": "Found in Museum, Relic Chambers, The Reliquary, The Reliquary."
+                },
+                "Boon of Justice": {
+                    "text": "Found in Chateau, Conservatory, Orchard, Plaza."
+                },
+                "Boon of the First Ones": {
+                    "text": "Found in Pit of the Chimera."
+                },
+                "Boundless Realms": {
+                    "text": "Found in Cold River, Temple, The Harbour Bridge, The Solaris Temple Level 1, The Solaris Temple Level 2, The Twilight Temple."
+                },
+                "Bowyer's Dream": {
+                    "text": "Dropped by map boss, Ashen Wood, Leyline, Graveyard, Canyon."
+                },
+                "Broken Promises": {
+                    "text": "Dropped by map boss, Mausoleum."
+                },
+                "Broken Truce": {
+                    "text": "Dropped by Thane Jorgin (Immortal Syndicate)."
+                },
+                "Brother's Stash": {
+                    "text": "Found in Cemetery, Grave Trough, Graveyard."
+                },
+                "Brotherhood in Exile": {
+                    "text": "Found in Chateau, Orchard, Plaza."
+                },
+                "Brush, Paint and Palette": {
+                    "text": "Dropped by map boss, Sepulchre, Phantasmagoria, The Putrid Cloister, Waste Pool, Core."
+                },
+                "Buried Treasure": {
+                    "text": "Found in Crystal Ore, Dig, Excavation, Flooded Mine, Geode, Grotto."
+                },
+                "Burning Blood": {
+                    "text": "Found in Forge of the Phoenix, Lava Chamber."
+                },
+                "Call to the First Ones": {
+                    "text": "Found in Bramble Valley, Dark Forest, Forbidden Woods, The Northern Forest, Thicket."
+                },
+                "Cameria's Cut": {
+                    "text": "Dropped by Cameria the Coldblooded (Immortal Syndicate)."
+                },
+                "Cartographer's Delight": {
+                    "text": "Found in The Foothills, The Harbour Bridge."
+                },
+                "Chaotic Disposition": {
+                    "text": "Found in Poorjoy's Asylum."
+                },
+                "Chasing Risk": {
+                    "text": "Dropped by The Vaal Omnitect, final boss of The Temple of Atzoatl."
+                },
+                "Checkmate": {
+                    "text": "Found in Academy, Museum."
+                },
+                "Choking Guilt": {
+                    "text": "Dropped by The Infinite Hunger."
+                },
+                "Costly Curio": {
+                    "text": "Found in Museum, Relic Chambers."
+                },
+                "Council of Cats": {
+                    "text": "Dropped by Al-Hezmin, The Hunter (Conqueror)."
+                },
+                "Coveted Possession": {
+                    "text": "Found in Bone Crypt, The Catacombs, The Ossuary, The Ossuary."
+                },
+                "Cursed Words": {
+                    "text": "Found in Cemetery, Grave Trough, Graveyard."
+                },
+                "Dark Dreams": {
+                    "text": "Dropped by Minara Anemina (Rogue Exile)."
+                },
+                "Dark Temptation": {
+                    "text": "Found in hidden chests (Azurite Mine - Delve)."
+                },
+                "Darker Half": {
+                    "text": "Dropped by Delirium currency rewards."
+                },
+                "Deadly Joy": {
+                    "text": "Found in Poorjoy's Asylum."
+                },
+                "Death": {
+                    "text": "Found in Bog, Marshes, Mud Geyser, The Karui Fortress."
+                },
+                "Deathly Designs": {
+                    "text": "Dropped by Ash Lessard (Rogue Exile)."
+                },
+                "Dementophobia": {
+                    "text": "Dropped by Conquerors and High Templar Venarius (Cortex)."
+                },
+                "Demigod's Wager": {
+                    "text": "Unconfirmed drop location."
+                },
+                "Desecrated Virtue": {
+                    "text": "Dropped by Aul, the Crystal King."
+                },
+                "Desperate Crusade": {
+                    "text": "Found in Basilica, Residence."
+                },
+                "Destined to Crumble": {
+                    "text": "Found in Academy, Museum, Scriptorium."
+                },
+                "Dialla's Subjugation": {
+                    "text": "Found in Cold River, Temple, The Solaris Temple Level 1, The Twilight Temple."
+                },
+                "Disdain": {
+                    "text": "Found in The Maven's Crucible."
+                },
+                "Divine Beauty": {
+                    "text": "Dropped by map boss of Underground Sea, Maelström of Chaos, and Sea Witches in Lava Chamber, Mineral Pools, Whakawairua Tuahu."
+                },
+                "Divine Justice": {
+                    "text": "Found in Armourer's Strongbox."
+                },
+                "Doedre's Madness": {
+                    "text": "Dropped by Doedre, act/map boss The Harvest, Doedre's Cellpool, The Rotting Core, Phantasmagoria, Core, Waste Pool, Sepulchre, The Putrid Cloister."
+                },
+                "Doryani's Epiphany": {
+                    "text": "Unconfirmed, speculated to be found in Prohibited Library."
+                },
+                "Draped in Dreams": {
+                    "text": "Unconfirmed drop location."
+                },
+                "Duality": {
+                    "text": "Dropped by Architects in the Temple of Atzoatl (not Incursions)."
+                },
+                "Dying Anguish": {
+                    "text": "Found in Arsenal, Colonnade, Ghetto, Port, Precinct, Promenade."
+                },
+                "Dying Light": {
+                    "text": "Dropped by The Shaper."
+                },
+                "Earth Drinker": {
+                    "text": "Found in Desert, Desert Spring, Dry Sea, Dunes, The Foothills, The Oasis, The Vastiri Desert."
+                },
+                "Echoes of Love": {
+                    "text": "Found in Core, Overgrown Ruin, Overgrown Shrine."
+                },
+                "Emperor of Purity": {
+                    "text": "Found in Overgrown Ruin, Overgrown Shrine, The Chamber of Sins Level 1, The Chamber of Sins Level 2."
+                },
+                "Emperor's Luck": {
+                    "text": "Found in Courtyard, Gardens, Orchard, Terrace, The High Gardens, The Imperial Gardens."
+                },
+                "Endless Night": {
+                    "text": "Unconfirmed drop location."
+                },
+                "Etched in Blood": {
+                    "text": "Dropped by map boss, Dark Forest."
+                },
+                "Eternal Bonds": {
+                    "text": "Found in Map chests (Contracts and Blueprints - Heist)."
+                },
+                "Ever-Changing": {
+                    "text": "Dropped by maps opened via Kirac missions."
+                },
+                "Fateful Meeting": {
+                    "text": "Dropped by Vaal Flesh Merchant."
+                },
+                "Forbidden Power": {
+                    "text": "Dropped by act/map boss, The Solaris Temple Level 2, The Harbour Bridge, Cold River, The Twilight Temple, Temple."
+                },
+                "From Bone to Ashes": {
+                    "text": "Found in Caldera, Coves, Estuary, Lava Lake, Shore, Strand, Volcano."
+                },
+                "Further Invention": {
+                    "text": "Found in Foundry, Vault."
+                },
+                "Gemcutter's Mercy": {
+                    "text": "Found in Gem chests (Azurite Mine - Delve)."
+                },
+                "Gemcutter's Promise": {
+                    "text": "Found in Colonnade, Promenade, The Ebony Barracks, The Lunaris Concourse."
+                },
+                "Gift of Asenath": {
+                    "text": "Found in Dig, Grotto."
+                },
+                "Gift of the Gemling Queen": {
+                    "text": "Found in Crystal Ore, Dig, Excavation, Flooded Mine, Geode, Grotto, The Quarry, The Tunnel."
+                },
+                "Glimmer of Hope": {
+                    "text": "Found in Flooded Mine, Mineral Pools, The Cavern of Anger, Underground Sea."
+                },
+                "Grave Knowledge": {
+                    "text": "Found in Bone Crypt, Cursed Crypt, Necropolis, The Coward's Trial, The Ossuary."
+                },
+                "Guardian's Challenge": {
+                    "text": "Sold by Kirac."
+                },
+                "Harmony of Souls": {
+                    "text": "Dropped by map boss, Sepulchre, Overgrown Shrine, Cells."
+                },
+                "Haunting Shadows": {
+                    "text": "Found in The Twilight Temple."
+                },
+                "Her Mask": {
+                    "text": "Found in all maps."
+                },
+                "Heterochromia": {
+                    "text": "Found in Estuary, The Twilight Temple."
+                },
+                "Home": {
+                    "text": "Found in Alleyways, Ancient City, Arcade, Bazaar, Chateau, City Square, Crimson Township, Haunted Mansion, Residence, Sunken City, Tower."
+                },
+                "Hope": {
+                    "text": "Found in all T1 maps."
+                },
+                "House of Mirrors": {
+                    "text": "Found in The Alluring Abyss."
+                },
+                "Hubris": {
+                    "text": "Found in Jeweller's Strongboxes."
+                },
+                "Humility": {
+                    "text": "Found in Channel, Frozen Cabins, The Aqueduct, The Blood Aqueduct, Waterways."
+                },
+                "Hunter's Resolve": {
+                    "text": "Found in Forking River, Ramparts, The Riverways, The Southern Forest."
+                },
+                "Hunter's Reward": {
+                    "text": "Unconfirmed drop location."
+                },
+                "Immortal Resolve": {
+                    "text": "Dropped by map boss, Carcass."
+                },
+                "Imperfect Memories": {
+                    "text": "Dropped by High Templar Venarius (Cortex)."
+                },
+                "Imperial Legacy": {
+                    "text": "Found in Desert, Desert Spring, Dry Sea, Dunes, Pillars of Arun."
+                },
+                "Jack in the Box": {
+                    "text": "Found in Arsenal, Colonnade, Ghetto, Port, Precinct, Promenade, The Docks, The Ebony Barracks, The Grain Gate, The Grand Promenade, The Harbour Bridge, The Imperial Fields, The Lunaris Concourse, The Quay, The Sarn Ramparts, The Slums."
+                },
+                "Judging Voices": {
+                    "text": "Unconfirmed drop location."
+                },
+                "Justified Ambition": {
+                    "text": "Dropped by Conquerors."
+                },
+                "Keeper's Corruption": {
+                    "text": "Found in Chayula's Domain."
+                },
+                "Lachrymal Necrosis": {
+                    "text": "Found in Basilica, Defiled Cathedral, The Chamber of Innocence, The Desecrated Chambers."
+                },
+                "Lantador's Lost Love": {
+                    "text": "Found in Atoll, Beach, Coral Ruins, Coves, Estuary, Lighthouse, Maelström of Chaos, Mao Kun, Peninsula, Pier, Plateau, Port, Prisoner's Gate, Reef, Shore, Strand, The Beacon, The Brine King's Reef, The Cavern of Anger, The Coast, The Karui Fortress, The Mud Flats, The Ridge, The Riverways, The Southern Forest, The Tidal Island, The Twilight Strand, The Western Forest, The Wetlands, Tropical Island, Whakawairua Tuahu, Wharf."
+                },
+                "Last Hope": {
+                    "text": "Found in Vaal Temple."
+                },
+                "Left to Fate": {
+                    "text": "Found in Forking River, Ramparts."
+                },
+                "Lethean Temptation": {
+                    "text": "Unconfirmed drop location."
+                },
+                "Light and Truth": {
+                    "text": "Found in Palace, Residence, The Upper Sceptre of God, Villa."
+                },
+                "Lingering Remnants": {
+                    "text": "Found in T11+ maps."
+                },
+                "Lost Worlds": {
+                    "text": "Sold by Kirac."
+                },
+                "Love Through Ice": {
+                    "text": "Dropped by Veritania, The Redeemer."
+                },
+                "Loyalty": {
+                    "text": "Found in Barrows, Caer Blaidd, Wolfpack's Den, Grotto, Lair, The Den."
+                },
+                "Lucky Connections": {
+                    "text": "Found in Pier, Port, Shipyard, The Docks, The Quay, Wharf."
+                },
+                "Lucky Deck": {
+                    "text": "Found in T7 maps."
+                },
+                "Luminous Trove": {
+                    "text": "Dropped by Aul, the Crystal King."
+                },
+                "Lysah's Respite": {
+                    "text": "Found in Maelström of Chaos, Mineral Pools, Underground Sea."
+                },
+                "Magnum Opus": {
+                    "text": "Found in Altered Distant Memory, Augmented Distant Memory, Rewritten Distant Memory, Twisted Distant Memory."
+                },
+                "Man With Bear": {
+                    "text": "Found in Cemetery."
+                },
+                "Mawr Blaidd": {
+                    "text": "Found in Bramble Valley, Dark Forest, Forbidden Woods."
+                },
+                "Merciless Armament": {
+                    "text": "Found in Armoury, Arsenal, Colonnade, Promenade."
+                },
+                "Might is Right": {
+                    "text": "Found in Mausoleum, Relic Chambers, Sepulchre, The Ossuary, The Reliquary."
+                },
+                "Misery in Darkness": {
+                    "text": "Dropped by boss, Abyssal City depth 90+ (Azurite Mine - Delve)."
+                },
+                "Mitts": {
+                    "text": "Found in Cold River, Forbidden Woods, Frozen Cabins, Glacier, Iceberg, Summit, The Ascent, The Descent, The Solaris Temple Level 1, The Solaris Temple Level 2."
+                },
+                "Monochrome": {
+                    "text": "Found in Acton's Nightmare, Caer Blaidd, Wolfpack's Den, Death and Taxes, Doryani's Machinarium, Hallowed Ground, Infused Beachhead, Maelström of Chaos, Mao Kun, Oba's Cursed Trove, Olmec's Sanctum, Pillars of Arun, Poorjoy's Asylum, The Beachhead, The Beachhead, The Beachhead, The Coward's Trial, The Hall of Grandmasters, The Putrid Cloister, The Twilight Temple, The Vinktar Square, Vaults of Atziri, Whakawairua Tuahu."
+                },
+                "More is Never Enough": {
+                    "text": "Found in Vault. Dropped by map boss, Cold River, Sunken City, Fields, Cemetary, Infested Valley, Summit, Reef, Siege, Terrace."
+                },
+                "No Traces": {
+                    "text": "Found in Mausoleum, Relic Chambers, Sepulchre, The Ossuary, The Ossuary, The Reliquary."
+                },
+                "Nook's Crown": {
+                    "text": "Dropped by Catarina, Master of Undeath in Mastermind's Lair."
+                },
+                "Parasitic Passengers": {
+                    "text": "Found in Arachnid Tomb, Channel, Infested Valley."
+                },
+                "Peaceful Moments": {
+                    "text": "Found in Courtyard, Gardens, Orchard, Terrace."
+                },
+                "Perfection": {
+                    "text": "Dropped by Elder Guardians."
+                },
+                "Prejudice": {
+                    "text": "Found in Redeemer-influenced maps."
+                },
+                "Pride Before the Fall": {
+                    "text": "Found in Caldera, Volcano."
+                },
+                "Pride of the First Ones": {
+                    "text": "Found in Barrows, Caer Blaidd, Wolfpack's Den, Grotto, Lair."
+                },
+                "Prometheus' Armoury": {
+                    "text": "Dropped by Haku (Immortal Syndicate)."
+                },
+                "Prosperity": {
+                    "text": "Found in Atoll, Beach, Coral Ruins, Coves, Estuary, Lighthouse, Maelström of Chaos, Mao Kun, Peninsula, Pier, Plateau, Port, Reef, Shipyard, Shore, Strand, Tropical Island, Whakawairua Tuahu, Wharf."
+                },
+                "Rain of Chaos": {
+                    "text": "Found in Castle Ruins, Fields, The Crossroads, The Imperial Fields."
+                },
+                "Rain Tempter": {
+                    "text": "Found in Courtyard, Gardens, Orchard, Terrace, The High Gardens."
+                },
+                "Rats": {
+                    "text": "Found in Arsenal, Factory, The Grain Gate, The Imperial Fields."
+                },
+                "Rebirth": {
+                    "text": "Found in The Ashen Fields, The Bath House, The Battlefront, The Beacon, The Blood Aqueduct, The Broken Bridge, The Control Blocks, The Crypt, The Crystal Veins, The Desecrated Chambers, The Foothills, The Oasis, The Ossuary, The Quarry, The Reliquary, The Ruined Square, The Slave Pens, The Vastiri Desert."
+                },
+                "Rebirth and Renewal": {
+                    "text": "Unconfirmed drop location."
+                },
+                "Reckless Ambition": {
+                    "text": "Dropped by The Eradicator (Elder Guardian)."
+                },
+                "Remembrance": {
+                    "text": "Found in Light Jewellery chests in Primeval Ruins, Abbyssal City, Vaal Outpost nodes (Azurite mine - Delve)."
+                },
+                "Sambodhi's Vow": {
+                    "text": "Dropped by Immortal Syndicate members."
+                },
+                "Sambodhi's Wisdom": {
+                    "text": "Found in Dunes."
+                },
+                "Scholar of the Seas": {
+                    "text": "Found in Coves, Reef, Strand, The Brine King's Reef, Whakawairua Tuahu."
+                },
+                "Seven Years Bad Luck": {
+                    "text": "Found in Crimson Temple, Defiled Cathedral, Sepulchre."
+                },
+                "Shard of Fate": {
+                    "text": "Found in Overgrown Ruin, Overgrown Shrine, The Chamber of Sins Level 2."
+                },
+                "Silence and Frost": {
+                    "text": "Dropped by Farrul, First of the Plains (Bestiary)."
+                },
+                "Society's Remorse": {
+                    "text": "Found in Voltaxic Sulphite deposits."
+                },
+                "Something Dark": {
+                    "text": "Dropped by Breachlords in Breachstones."
+                },
+                "Struck by Lightning": {
+                    "text": "Found in Cemetery, Colonnade, Courtyard, Graveyard, Infested Valley, Leyline, Promenade, Shipyard, Stagnation, The Vinktar Square, Tower, Villa, Wharf."
+                },
+                "Succor of the Sinless": {
+                    "text": "Dropped by Baran, The Crusader."
+                },
+                "Terrible Secret of Space": {
+                    "text": "Dropped by map boss, Alleyways, Vault, Coves, Peninsula, Grotto."
+                },
+                "The Academic": {
+                    "text": "Found in Academy, Museum."
+                },
+                "The Admirer": {
+                    "text": "Found in Ancient City, Doryani's Machinarium, Maze, Vaal Pyramid, Vaal Temple, Vaults of Atziri."
+                },
+                "The Adventuring Spirit": {
+                    "text": "Found in Vaults of Atziri."
+                },
+                "The Aesthete": {
+                    "text": "Dropped by act/map boss, The Harvest, Rotting Core, Carcass, Tower, Scriptorium, Core, Cells."
+                },
+                "The Apothecary": {
+                    "text": "Found in Crimson Temple, Crimson Township, Defiled Cathedral, Haunted Mansion."
+                },
+                "The Archmage's Right Hand": {
+                    "text": "Found in Chayula's Domain."
+                },
+                "The Arena Champion": {
+                    "text": "Dropped by map boss, Colosseum, Pit of the Chimera, Pit."
+                },
+                "The Army of Blood": {
+                    "text": "Found in Poorjoy's Asylum, Shrine, The Lunaris Temple Level 2."
+                },
+                "The Artist": {
+                    "text": "Drops anywhere."
+                },
+                "The Aspirant": {
+                    "text": "Dropped by Oshabi, Avatar of the Grove."
+                },
+                "The Astromancer": {
+                    "text": "Dropped by Corpse Stitcher."
+                },
+                "The Avenger": {
+                    "text": "Found in Lava Chamber, Maelström of Chaos, Mineral Pools, Primordial Blocks, Underground Sea."
+                },
+                "The Awakened": {
+                    "text": "Dropped by Metamorph monsters."
+                },
+                "The Battle Born": {
+                    "text": "Found in Caldera, Kaom's Dream, Kaom's Stronghold, Volcano."
+                },
+                "The Bear Woman": {
+                    "text": "Dropped by map boss, Barrows, Cemetary."
+                },
+                "The Beast": {
+                    "text": "Found in The Belly of the Beast, The Belly of the Beast Level 1, The Belly of the Beast Level 2."
+                },
+                "The Betrayal": {
+                    "text": "Found in Burial Chambers, Castle Ruins, Fungal Hollow, Mesa, Spider Forest, Strand, The Ashen Fields, The Crossroads, The Northern Forest, The Riverways, The Southern Forest, The Western Forest."
+                },
+                "The Bitter Blossom": {
+                    "text": "Dropped by boss, Oshabi, Avatar of the Grove (Harvest)."
+                },
+                "The Blazing Fire": {
+                    "text": "Found in Alleyways, City Square, Crimson Temple, Defiled Cathedral, Haunted Mansion, Lookout, Silo, The Desecrated Chambers, The Ravaged Square, The Ruined Square, The Torched Courts, The Torched Courts."
+                },
+                "The Blessing of Moosh": {
+                    "text": "Dropped by Darkshrines in The Lord's Labyrinth."
+                },
+                "The Body": {
+                    "text": "Found in Armourer's Strongboxes."
+                },
+                "The Bones": {
+                    "text": "Dropped by Minara Anemina (Rogue Exile)."
+                },
+                "The Brawny Battle Mage": {
+                    "text": "Found in Burial Chambers, Phantasmagoria, Sepulchre, Spider Forest, The Putrid Cloister, Waste Pool."
+                },
+                "The Breach": {
+                    "text": "Dropped by Null Portals in Elder-Influenced maps."
+                },
+                "The Brittle Emperor": {
+                    "text": "Dropped by The Brittle Emperor, Voll, Emperor of Purity."
+                },
+                "The Cache": {
+                    "text": "Found in Maelström of Chaos, Mineral Pools, Underground Sea, Vault, Vaults of Atziri."
+                },
+                "The Cacophony": {
+                    "text": "Dropped by map boss, Sepulchre, Cemetary, Underground Sea, Maelström of Chaos, Reef, Crimson Temple."
+                },
+                "The Calling": {
+                    "text": "Dropped by Beyond demons."
+                },
+                "The Card Sharp": {
+                    "text": "Dropped by Ahuana, Architect of Ceremonies, Paquate, Architect of Corruption, Zalatl, Architect of Thaumaturgy in Temporal Incursions or Alva's Memory of Reverse Incursion."
+                },
+                "The Carrion Crow": {
+                    "text": "Found in Channel, City Square, Colonnade, Courtyard, Promenade, Ramparts, The Aqueduct, The Ascent, The Battlefront, The Blood Aqueduct, The City of Sarn, The Ebony Barracks, The Grand Promenade, The Imperial Gardens, The Western Forest."
+                },
+                "The Cartographer": {
+                    "text": "Dropped by Cartographer's Strongboxes."
+                },
+                "The Cataclysm": {
+                    "text": "Drops in Vaal sides areas of area level 72+."
+                },
+                "The Catalyst": {
+                    "text": "Found in Ancient City, Doryani's Machinarium, Maze, The Ancient Pyramid, The Causeway, The Temple of Decay Level 1, The Temple of Decay Level 2, The Vaal City, Vaal Pyramid, Vaal Temple, Vaults of Atziri."
+                },
+                "The Catch": {
+                    "text": "Found in Atoll, Beach, Coves, Peninsula, Shipyard, Shore, Strand, Tropical Island."
+                },
+                "The Celestial Justicar": {
+                    "text": "Found in Bone Crypt, Cursed Crypt, The Coward's Trial, The Crypt."
+                },
+                "The Celestial Stone": {
+                    "text": "Dropped by Jeweller's Strongboxes."
+                },
+                "The Chains that Bind": {
+                    "text": "Found in Cage, Cells, Dungeon, Pen, Shavronne's Tower, The Control Blocks, The Slave Pens."
+                },
+                "The Cheater": {
+                    "text": "Dropped by Guff 'Tiny' Grenn."
+                },
+                "The Chosen": {
+                    "text": "Found in Breach encounters."
+                },
+                "The Coming Storm": {
+                    "text": "Found in Cemetery, Colonnade, Graveyard, Infested Valley, Leyline, Promenade, Shipyard, Stagnation, Villa, Wharf."
+                },
+                "The Conduit": {
+                    "text": "Dropped by map boss, Palace, Villa."
+                },
+                "The Craving": {
+                    "text": "Dropped by act/map boss, The Den, The Coward's Trial, Acton's Nightmare, Bone Crypt."
+                },
+                "The Cursed King": {
+                    "text": "Found in Caer Blaidd, Wolfpack's Den."
+                },
+                "The Damned": {
+                    "text": "Found in Ancient City, Maze, Vaal Pyramid, Vaal Temple, Vaults of Atziri."
+                },
+                "The Dapper Prodigy": {
+                    "text": "Found in Palace, Residence, Villa."
+                },
+                "The Dark Mage": {
+                    "text": "Found in Overgrown Ruin, Overgrown Shrine, The Chamber of Sins Level 2."
+                },
+                "The Darkest Dream": {
+                    "text": "Found in Whakawairua Tuahu."
+                },
+                "The Deal": {
+                    "text": "Dropped by Cameria the Coldblooded (Immortal Syndicate)."
+                },
+                "The Deceiver": {
+                    "text": "Found in Arena, Colosseum, Racecourse, The Grand Arena."
+                },
+                "The Deep Ones": {
+                    "text": "Dropped by act boss, the Brine King's Reef. Found in Coral Ruins, Coves, Reef, Strand, The Brine King's Reef, Whakawairua Tuahu."
+                },
+                "The Demon": {
+                    "text": "Dropped by Kitava, The Destroyer."
+                },
+                "The Demoness": {
+                    "text": "Found in Bramble Valley, Dark Forest, Forbidden Woods, The Northern Forest."
+                },
+                "The Destination": {
+                    "text": "Found in Beach, Shore, Tropical Island."
+                },
+                "The Doctor": {
+                    "text": "Found in Burial Chambers, Phantasmagoria, Sepulchre, Spider Forest, The Putrid Cloister, Waste Pool."
+                },
+                "The Doppelganger": {
+                    "text": "Found in The Crossroads, Whakawairua Tuahu."
+                },
+                "The Dragon": {
+                    "text": "Found in Bramble Valley, Dark Forest, Forbidden Woods."
+                },
+                "The Dragon's Heart": {
+                    "text": "Found in T11+ maps."
+                },
+                "The Dreamer": {
+                    "text": "Dropped by Agents of the Void in Shaper-Influenced maps."
+                },
+                "The Dreamland": {
+                    "text": "Dropped by Cartographer's Strongboxes."
+                },
+                "The Drunken Aristocrat": {
+                    "text": "Found in Academy, Bazaar, Crystal Ore, Pier, Ramparts, Residence."
+                },
+                "The Dungeon Master": {
+                    "text": "Found in Cage, Cells, Dungeon, Pen."
+                },
+                "The Easy Stroll": {
+                    "text": "Found in Courtyard, Gardens, Orchard, Terrace."
+                },
+                "The Eldritch Decay": {
+                    "text": "Dropped by Elder Guardians."
+                },
+                "The Emptiness": {
+                    "text": "Found in Maelström of Chaos."
+                },
+                "The Encroaching Darkness": {
+                    "text": "Found in T6+ maps."
+                },
+                "The Endless Darkness": {
+                    "text": "Dropped by destroyed Harbinger portals in The Beachhead, Infused Beachhead, Delve, or Kirac's Memory of the Phaaryl."
+                },
+                "The Endurance": {
+                    "text": "Found in Crystal Ore, Dig, Excavation, Flooded Mine, Geode, Grotto, The Crystal Veins, The Mines Level 1, The Mines Level 2, The Quarry, The Tunnel."
+                },
+                "The Enforcer": {
+                    "text": "Unconfirmed drop location."
+                },
+                "The Enlightened": {
+                    "text": "Found in Belfry, Crimson Temple, Defiled Cathedral, Ivory Temple, Lookout, Temple."
+                },
+                "The Enthusiasts": {
+                    "text": "Found in Academy, Museum, Scriptorium."
+                },
+                "The Escape": {
+                    "text": "Dropped by Breachlords in Breachstones."
+                },
+                "The Eternal War": {
+                    "text": "Dropped by Conquerors."
+                },
+                "The Ethereal": {
+                    "text": "Found in The Alluring Abyss, The Apex of Sacrifice, The Eternal Labyrinth."
+                },
+                "The Explorer": {
+                    "text": "Found in The Dread Thicket, Thicket."
+                },
+                "The Eye of the Dragon": {
+                    "text": "Found in Forge of the Phoenix, Sulphur Vents, The Boiling Lake."
+                },
+                "The Fathomless Depths": {
+                    "text": "Found in Flooded Mine, Mineral Pools, Underground Sea."
+                },
+                "The Feast": {
+                    "text": "Found in Lair of the Hydra, The Sewers, The Toxic Conduits, Toxic Sewer, Waste Pool."
+                },
+                "The Fiend": {
+                    "text": "Found in Foundry, Poorjoy's Asylum, Shrine."
+                },
+                "The Finishing Touch": {
+                    "text": "Dropped by Hillock, the Blacksmith."
+                },
+                "The Fishmonger": {
+                    "text": "Dropped by Drought-Maddened Rhoa, Skullbeak."
+                },
+                "The Fletcher": {
+                    "text": "Dropped by Eyepecker, Lieutenant of the Bow, Lord of the Ashen Arrow, Mirage of Bones, Nightwane, Steelpoint the Avenger, Stonebeak, Battle Fowl, The Animal Pack."
+                },
+                "The Flora's Gift": {
+                    "text": "Found in maps T1-9,  Ashen Wood, Bramble Valley, Dark Forest, Forbidden Woods, Jungle Valley, Lair, Ramparts, Spider Forest, Tropical Island."
+                },
+                "The Fool": {
+                    "text": "Dropped by Immortal Syndicate members."
+                },
+                "The Forgotten Treasure": {
+                    "text": "Found in Temple."
+                },
+                "The Formless Sea": {
+                    "text": "Found in Coves, Reef, Strand, Whakawairua Tuahu."
+                },
+                "The Forsaken": {
+                    "text": "Found in Bone Crypt, Cursed Crypt, Necropolis, The Coward's Trial."
+                },
+                "The Forward Gaze": {
+                    "text": "Found in Doryani's Machinarium."
+                },
+                "The Fox": {
+                    "text": "Found in Barrows, Castle Ruins, Fields, Sunken City, The Crossroads, The Fellshrine Ruins, The Riverways, The Vaal City, The Western Forest."
+                },
+                "The Fox in the Brambles": {
+                    "text": "Found in Courtyard, Gardens, Orchard, Terrace."
+                },
+                "The Gambler": {
+                    "text": "Found in any map."
+                },
+                "The Garish Power": {
+                    "text": "Found in Overgrown Ruin, Overgrown Shrine, The Chamber of Sins Level 1, The Chamber of Sins Level 2."
+                },
+                "The Gemcutter": {
+                    "text": "Drops anywhere. Including Gemcutter's Strongboxes."
+                },
+                "The Gentleman": {
+                    "text": "Found in Ghetto, Precinct, The Grain Gate, The Sarn Ramparts, The Slums."
+                },
+                "The Gladiator": {
+                    "text": "Found in Arena, Colosseum, Pit, Pit of the Chimera."
+                },
+                "The Golden Era": {
+                    "text": "Found in Basilica, Ivory Temple, Residence."
+                },
+                "The Greatest Intentions": {
+                    "text": "Unconfirmed, speculated to be dropped by The Shaper."
+                },
+                "The Gulf": {
+                    "text": "Dropped by Uber Elder."
+                },
+                "The Hale Heart": {
+                    "text": "Dropped by Elder Guardians."
+                },
+                "The Harvester": {
+                    "text": "Found in Castle Ruins, Fields, The Imperial Fields."
+                },
+                "The Hermit": {
+                    "text": "Found in The Ashen Fields, The Broken Bridge, The Causeway, The Crossroads, The Fellshrine Ruins, The Northern Forest, The Vaal City."
+                },
+                "The Heroic Shot": {
+                    "text": "Dropped by Arcanist's Strongboxes."
+                },
+                "The Hive of Knowledge": {
+                    "text": "Found in Maze, Vaal Pyramid, Vaal Temple."
+                },
+                "The Hoarder": {
+                    "text": "Found in Maelström of Chaos, Mineral Pools, Underground Sea, Vault, Vaults of Atziri."
+                },
+                "The Hook": {
+                    "text": "Dropped by High Templar Venarius (Cortex)."
+                },
+                "The Hunger": {
+                    "text": "Found in Carcass, Core, Malformation, Phantasmagoria, The Belly of the Beast, The Belly of the Beast Level 1, The Belly of the Beast Level 2, The Harvest, The Rotting Core."
+                },
+                "The Immortal": {
+                    "text": "Found in The Hall of Grandmasters."
+                },
+                "The Incantation": {
+                    "text": "Found in Burial Chambers, Phantasmagoria, Sepulchre, Spider Forest, The Putrid Cloister, Waste Pool."
+                },
+                "The Innocent": {
+                    "text": "Found in Basilica, Defiled Cathedral, The Chamber of Innocence."
+                },
+                "The Inoculated": {
+                    "text": "Found in Acid Caverns, Bog, Marshes, Mud Geyser, Primordial Pool, Stagnation, Sulphur Vents."
+                },
+                "The Insane Cat": {
+                    "text": "Dropped by Kosis, The Revelation, Omniphobia, Fear Manifest."
+                },
+                "The Insatiable": {
+                    "text": "Found in Carcass, Core, The Rotting Core."
+                },
+                "The Inventor": {
+                    "text": "Found in Doryani's Machinarium, Maze, The Temple of Decay Level 1, The Temple of Decay Level 2, Vaal Pyramid, Vaal Temple, Vaults of Atziri."
+                },
+                "The Jester": {
+                    "text": "Dropped by Ash Lessard (Rogue Exile)."
+                },
+                "The Jeweller's Boon": {
+                    "text": "Found in Crystal Ore, Grotto, Mineral Pools, Primordial Blocks."
+                },
+                "The Journalist": {
+                    "text": "Found in Alleyways, City Square, Crimson Temple, Defiled Cathedral, Haunted Mansion, Lookout, Silo."
+                },
+                "The Journey": {
+                    "text": "Found in Atoll, Coral Ruins, Coves, Estuary, Lighthouse, Maelström of Chaos, Mao Kun, Peninsula, Pier, Plateau, Port, Reef, Shipyard, Shore, Strand, Tropical Island, Whakawairua Tuahu, Wharf."
+                },
+                "The King's Blade": {
+                    "text": "Found in Arena, Colosseum, Pit, Pit of the Chimera."
+                },
+                "The King's Heart": {
+                    "text": "Found in Caldera, Volcano."
+                },
+                "The Landing": {
+                    "text": "Found in Mao Kun, Shore, Strand, Whakawairua Tuahu."
+                },
+                "The Last One Standing": {
+                    "text": "Found in Arena, Colosseum, Pit, Pit of the Chimera."
+                },
+                "The Last Supper": {
+                    "text": "Found in Poorjoy's Asylum."
+                },
+                "The Leviathan": {
+                    "text": "Found in Maelström of Chao."
+                },
+                "The Lich": {
+                    "text": "Dropped by Burtok, Conjurer of Bones, Xixic, High Necromancer."
+                },
+                "The Life Thief": {
+                    "text": "Found in Alleyways, City Square, Crimson Temple, Defiled Cathedral, Haunted Mansion, Lookout, Silo."
+                },
+                "The Lion": {
+                    "text": "Dropped by act/map boss, The Mud Flats (Act 6), Caldera."
+                },
+                "The Long Con": {
+                    "text": "Dropped by Izaro's Treasure chests in the Enriched Eternal Labyrinth."
+                },
+                "The Lord in Black": {
+                    "text": "Dropped by K'tash, the Hate Shepherd."
+                },
+                "The Lord of Celebration": {
+                    "text": "Found in Basilica, Chateau, Conservatory, Crimson Temple, Crimson Township, Haunted Mansion, Ivory Temple, Laboratory, Palace, Residence, Siege, Temple, Vault, Villa."
+                },
+                "The Lover": {
+                    "text": "Found in Maelström of Chaos, Underground Sea."
+                },
+                "The Lunaris Priestess": {
+                    "text": "Found in Cold River, Moon Temple, The Harbour Bridge, The Lunaris Temple Level 1, The Lunaris Temple Level 2, The Twilight Temple."
+                },
+                "The Mad King": {
+                    "text": "Found in Caldera, Colosseum, Dark Forest, Reef."
+                },
+                "The Magma Crab": {
+                    "text": "Dropped by Magnus Stonethorn."
+                },
+                "The Master": {
+                    "text": "Found in Lair, Pen."
+                },
+                "The Master Artisan": {
+                    "text": "Found in Artisan's Strongboxes."
+                },
+                "The Mercenary": {
+                    "text": "Found in Castle Ruins, The Broken Bridge."
+                },
+                "The Messenger": {
+                    "text": "Found in Crystal Ore, Port."
+                },
+                "The Metalsmith's Gift": {
+                    "text": "Found in The Coast, The Karui Fortress, The Mud Flats."
+                },
+                "The Mind's Eyes": {
+                    "text": "Dropped by map boss, Grotto, Bone Crypt."
+                },
+                "The Mountain": {
+                    "text": "Found in Glacier, Summit, The Ascent, The Descent, Volcano."
+                },
+                "The Nurse": {
+                    "text": "Found in Carcass, Cells, Core, Shavronne's Tower, The Harvest, Tower."
+                },
+                "The Oath": {
+                    "text": "Found in Carcass, Core, Malformation, Phantasmagoria, The Belly of the Beast, The Rotting Core."
+                },
+                "The Obscured": {
+                    "text": "Dropped by Abyss monsters, including from Abyss nodes in Delve."
+                },
+                "The Offering": {
+                    "text": "Dropped by act/map boss, The Rotting Core, Prison Rooftop, Carcass, Tower, Scriptorium, Core, Cells."
+                },
+                "The Offspring": {
+                    "text": "Dropped by Gorulis, Will-Thief, Murgeth Bogsong, Ryslatha, the Puppet Mistress."
+                },
+                "The Old Man": {
+                    "text": "Found in Lighthouse, Peninsula, Pier, Shore, Strand, Tropical Island, Wharf."
+                },
+                "The One That Got Away": {
+                    "text": "Found in Strand."
+                },
+                "The One With All": {
+                    "text": "Found in Barrows, Burial Chambers, Cemetery, Grave Trough, Graveyard."
+                },
+                "The Opulent": {
+                    "text": "Found in Basilica, Chateau, Conservatory, Crimson Temple, Crimson Township, Haunted Mansion, Ivory Temple, Laboratory, Palace, Relic Chambers, Residence, Temple, The Twilight Temple, Vault, Vaults of Atziri, Villa."
+                },
+                "The Pack Leader": {
+                    "text": "Found in Ashen Wood, Bramble Valley, Dark Forest, Forbidden Woods, Jungle Valley, Lair, Ramparts, Spider Forest, Stagnation, Thicket, Tropical Island."
+                },
+                "The Pact": {
+                    "text": "Found in Pier, Port, Shipyard, The Quay, Wharf."
+                },
+                "The Patient": {
+                    "text": "Found in Armoury, Arsenal, Colonnade, Promenade."
+                },
+                "The Penitent": {
+                    "text": "Found in Cage, Cells, Dungeon, Pen."
+                },
+                "The Poet": {
+                    "text": "Found in Alleyways, Arcade, Bazaar, Port, The Marketplace, The Quay."
+                },
+                "The Polymath": {
+                    "text": "Found in Museum, Relic Chambers, The Reliquary, The Reliquary."
+                },
+                "The Porcupine": {
+                    "text": "Found in Courtyard, Gardens, Orchard, Plaza, Terrace, The High Gardens."
+                },
+                "The Price of Devotion": {
+                    "text": "Dropped by Uber Atziri, Queen of the Vaal."
+                },
+                "The Price of Loyalty": {
+                    "text": "Dropped by Zilquapa, Architect of the Breach."
+                },
+                "The Price of Prescience": {
+                    "text": "Dropped by Conqerors."
+                },
+                "The Price of Protection": {
+                    "text": "Dropped by Invasion bosses or Vaal side areas."
+                },
+                "The Primordial": {
+                    "text": "Found in Coves, Flooded Mine, Geode, Grotto, Peninsula, Vault, Waterways, Wharf."
+                },
+                "The Prince of Darkness": {
+                    "text": "Dropped by Eater of Souls, Nightmare's Omen."
+                },
+                "The Professor": {
+                    "text": "Found in Academy, Laboratory, Museum, Scriptorium."
+                },
+                "The Progeny of Lunaris": {
+                    "text": "Dropped by map boss, The Twilight Temple, Cold River."
+                },
+                "The Puzzle": {
+                    "text": "Dropped by Beyond demons."
+                },
+                "The Queen": {
+                    "text": "Found in Vaults of Atziri."
+                },
+                "The Rabbit's Foot": {
+                    "text": "Found in Bone Crypt, Cursed Crypt, The Coward's Trial."
+                },
+                "The Rabid Rhoa": {
+                    "text": "Dropped by map boss, Bog."
+                },
+                "The Realm": {
+                    "text": "Dropped by Breach monsters or Kirac Divination Card Mission maps."
+                },
+                "The Return of the Rat": {
+                    "text": "Found in Arsenal, Factory, The Grain Gate, The Refinery."
+                },
+                "The Risk": {
+                    "text": "Dropped by Izaro's Treasure chests in the Endgame Labyrinth and Diviner's Strongbox."
+                },
+                "The Rite of Elements": {
+                    "text": "Found in Coves, Flooded Mine, Geode, Grotto, Peninsula, Vault, Waterways, Wharf."
+                },
+                "The Road to Power": {
+                    "text": "Found in Castle Ruins, Dark Forest, Orchard, Shore."
+                },
+                "The Rusted Bard": {
+                    "text": "Unconfirmed drop location."
+                },
+                "The Ruthless Ceinture": {
+                    "text": "Found in Dig, Maze of the Minotaur, Summit, The Descent, The Foothills."
+                },
+                "The Sacrifice": {
+                    "text": "Found in The Temple of Atzoatl."
+                },
+                "The Saint's Treasure": {
+                    "text": "Found in Alleyways, Arcade, Bazaar, Ghetto, Port, Precinct, The Grain Gate, The Imperial Fields, The Marketplace, The Slums."
+                },
+                "The Samurai's Eye": {
+                    "text": "Dropped by boss, Abyssal Depths (Abyss)."
+                },
+                "The Scarred Meadow": {
+                    "text": "Found in Ashen Wood, Fields, Peninsula, The Old Fields."
+                },
+                "The Scavenger": {
+                    "text": "Dropped by act/map boss, The Caverns (Act 2), Canyon, Chateau, Channel."
+                },
+                "The Scholar": {
+                    "text": "Found in Academy, Museum, Scriptorium, The Archives, The Library."
+                },
+                "The Scout": {
+                    "text": "Found in Ashen Wood, Bramble Valley, Dark Forest, Forbidden Woods, Jungle Valley, Lair, Ramparts, Spider Forest, Stagnation, Thicket, Tropical Island."
+                },
+                "The Seeker": {
+                    "text": "Found in The Temple of Atzoatl."
+                },
+                "The Sephirot": {
+                    "text": "Dropped by act/map boss, The Upper Sceptre of God, Palace, Villa."
+                },
+                "The Shepherd's Sandals": {
+                    "text": "Found in Barrows, Grotto, Lair."
+                },
+                "The Shieldbearer": {
+                    "text": "Dropped by The Elder."
+                },
+                "The Shortcut": {
+                    "text": "Found in Vaal side areas and Labyrinth Trial areas of area level 80+."
+                },
+                "The Side Quest": {
+                    "text": "Found in Alleyways, Arachnid Tomb, Armoury, Castle Ruins, Forking River, Iceberg, Infested Valley, Mineral Pools, Primordial Blocks."
+                },
+                "The Sigil": {
+                    "text": "Found in Overgrown Ruin, Overgrown Shrine."
+                },
+                "The Siren": {
+                    "text": "Found in Maelström of Chaos, The Brine King's Reef, The Cavern of Anger, Underground Sea."
+                },
+                "The Skeleton": {
+                    "text": "Dropped by Fairgraves, Never Dying."
+                },
+                "The Soul": {
+                    "text": "Found in Cells, Core, Museum, Overgrown Shrine, Phantasmagoria, Sepulchre, Tower, Waste Pool."
+                },
+                "The Spark and the Flame": {
+                    "text": "Found in Atoll, Plateau."
+                },
+                "The Spoiled Prince": {
+                    "text": "Found in Vaal Pyramid."
+                },
+                "The Standoff": {
+                    "text": "Found in Crater, Estuary, Forge of the Phoenix, Lava Chamber, Lava Lake, Silo, The Ruined Square, The Torched Courts."
+                },
+                "The Stormcaller": {
+                    "text": "Found in Courtyard, Strand, Tower."
+                },
+                "The Strategist": {
+                    "text": "Dropped by Drox, The Warlord."
+                },
+                "The Summoner": {
+                    "text": "Found in Bone Crypt, Burial Chambers, Cage, Shavronne's Tower, Spider Forest, The Catacombs, The Lower Prison."
+                },
+                "The Sun": {
+                    "text": "Found in Cold River, Temple, The Harbour Bridge, The Solaris Temple Level 1, The Twilight Temple."
+                },
+                "The Surgeon": {
+                    "text": "Found in Overgrown Ruin, Overgrown Shrine."
+                },
+                "The Surveyor": {
+                    "text": "Found in Carcass, Core, Malformation, Phantasmagoria."
+                },
+                "The Survivalist": {
+                    "text": "Found in Flooded Mine, Mineral Pools, The Cavern of Anger, Underground Sea."
+                },
+                "The Sword King's Salute": {
+                    "text": "Found in Arena, Colosseum, Daresso's Dream, Pit, Pit of the Chimera, The Grand Arena."
+                },
+                "The Thaumaturgist": {
+                    "text": "Found in Foundry, Laboratory, Poorjoy's Asylum, Shrine."
+                },
+                "The Throne": {
+                    "text": "Found in Lair of the Hydra, Toxic Sewer, Waste Pool."
+                },
+                "The Tinkerer's Table": {
+                    "text": "Found in all maps."
+                },
+                "The Tireless Extractor": {
+                    "text": "Found in Factory, Silo."
+                },
+                "The Tower": {
+                    "text": "Found in Residence, Shavronne's Tower, The Sceptre of God, The Upper Sceptre of God, Tower."
+                },
+                "The Traitor": {
+                    "text": "Found in Promenade, Ramparts, The Battlefront, The Sarn Ramparts, The Solaris Concourse."
+                },
+                "The Transformation": {
+                    "text": "Dropped by Metamorph monsters."
+                },
+                "The Trial": {
+                    "text": "Found in T6 to T10 maps."
+                },
+                "The Tumbleweed": {
+                    "text": "Found in Desert Spring, Dunes."
+                },
+                "The Twilight Moon": {
+                    "text": "Found in Cold River, Moon Temple, Temple."
+                },
+                "The Twins": {
+                    "text": "Found in Cold River, Moon Temple, Temple, The Twilight Temple."
+                },
+                "The Tyrant": {
+                    "text": "Found in Ancient City, Arcade, Bazaar, Castle Ruins, Coral Ruins, Ghetto, Port, Precinct."
+                },
+                "The Undaunted": {
+                    "text": "Found in Conservatory, Courthouse, Precinct, Whakawairua Tuahu."
+                },
+                "The Undisputed": {
+                    "text": "Dropped by Chayula, Who Dreamt."
+                },
+                "The Unexpected Prize": {
+                    "text": "Found in Palace, Residence, Villa."
+                },
+                "The Union": {
+                    "text": "Found in Cemetery, Grave Trough, Graveyard."
+                },
+                "The Valkyrie": {
+                    "text": "Dropped by female Rogue Exiles."
+                },
+                "The Vast": {
+                    "text": "Found in Coral Ruins, Reef."
+                },
+                "The Visionary": {
+                    "text": "Found in Arena, Colosseum, Racecourse, The Grand Arena."
+                },
+                "The Void": {
+                    "text": "Found in The Shaper's Realm."
+                },
+                "The Warden": {
+                    "text": "Found in Cage, Cells, Dungeon, Pen, Shavronne's Tower, The Control Blocks, The Lower Prison, The Slave Pens."
+                },
+                "The Warlord": {
+                    "text": "Found in Armoury, Arsenal, Colonnade, Promenade."
+                },
+                "The Watcher": {
+                    "text": "Found in Geode, Grotto."
+                },
+                "The Web": {
+                    "text": "Found in Arachnid Nest, Arachnid Tomb, Jungle Valley, Spider Lair, Sunken City, Toxic Sewer."
+                },
+                "The Wedding Gift": {
+                    "text": "Found in Sunken City."
+                },
+                "The White Knight": {
+                    "text": "Found in Trial of Stinging Doubt."
+                },
+                "The Whiteout": {
+                    "text": "Dropped by map boss, Canyon."
+                },
+                "The Wilted Rose": {
+                    "text": "Found in Acton's Nightmare."
+                },
+                "The Wind": {
+                    "text": "Found in Atoll, Jungle Valley, Lighthouse, Mesa, Plateau, Summit."
+                },
+                "The Witch": {
+                    "text": "Found in Burial Chambers, Phantasmagoria, Sepulchre, Spider Forest, The Putrid Cloister, Waste Pool."
+                },
+                "The Wolf": {
+                    "text": "Found in Crystal Ore, Dig, Excavation, Flooded Mine, Geode, Grotto, The Tunnel."
+                },
+                "The Wolf's Legacy": {
+                    "text": "Dropped by Izaro's Treasure chests, Labryinth Troves and Silver Key caches in Eternal Labyrinths or Enriched Eternal Labyrinths."
+                },
+                "The Wolf's Shadow": {
+                    "text": "Found in Caer Blaidd, Wolfpack's Den, Dark Forest, Lair."
+                },
+                "The Wolven King's Bite": {
+                    "text": "Found in Dark Forest, Lair."
+                },
+                "The Wolverine": {
+                    "text": "Found in Glacier, Lair, Prisoner's Gate, Summit."
+                },
+                "The World Eater": {
+                    "text": "Dropped by Ghorr, the Grasping Maw."
+                },
+                "The Wrath": {
+                    "text": "Found in Belfry, Lava Lake, The Canals, The Cathedral Rooftop, The Cavern of Anger, The Feeding Trough."
+                },
+                "The Wretched": {
+                    "text": "Found in Acton's Nightmare, Bone Crypt, Cursed Crypt, Necropolis, The Coward's Trial."
+                },
+                "Thirst for Knowledge": {
+                    "text": "Found in Academy, Museum, Scriptorium, The Archives, The Library."
+                },
+                "Three Faces in the Dark": {
+                    "text": "Found in Arsenal, Factory, The Grain Gate, The Imperial Fields, The Marketplace, The Refinery."
+                },
+                "Three Voices": {
+                    "text": "Found in Arena, City Square, Courthouse, Courtyard, Crystal Ore, Forbidden Woods, Graveyard, Racecourse, Vaal Pyramid, Vaal Temple."
+                },
+                "Thunderous Skies": {
+                    "text": "Found in Courtyard, Shavronne's Tower, Strand, The Twilight Strand, The Vinktar Square, Tower."
+                },
+                "Time-Lost Relic": {
+                    "text": "Found in Battleground Graves, Bluffs, Cemetery, Crystal Ore, Desert Ruins, Dig, Dried Riverbed, Excavation, Flooded Mine, Forest Ruins, Geode, Grotto, Karui Wargraves, Mountainside, Rotting Temple, Sarn Slums, Scrublands, Shipwreck Reef, Utzaal Outskirts, Vaal Temple, Volcanic Island."
+                },
+                "Tranquillity": {
+                    "text": "Found in Ashen Wood, Fields, Peninsula, The Ashen Fields."
+                },
+                "Treasure Hunter": {
+                    "text": "Found in Caer Blaidd, Wolfpack's Den, Crystal Ore, Excavation, Flooded Mine, Fungal Hollow, Grotto, Lair, Maze of the Minotaur, Underground River, Underground Sea."
+                },
+                "Triskaidekaphobia": {
+                    "text": "Found in T13 maps. Dropped by Atziri in The Temple of Atzoatl's, Uber Atziri, The Feared."
+                },
+                "Turn the Other Cheek": {
+                    "text": "Found in The Library."
+                },
+                "Unchained": {
+                    "text": "Found in Arena, Colosseum, Pit, Pit of the Chimera."
+                },
+                "Underground Forest": {
+                    "text": "Drops in Petrified Forest biome in Delve, behind fractured walls."
+                },
+                "Unrequited Love": {
+                    "text": "Found in Maze, The Temple of Decay Level 1, Vaal Pyramid, Vaal Temple."
+                },
+                "Vanity": {
+                    "text": "Dropped by Vaal Vessels in Vaal side areas."
+                },
+                "Vile Power": {
+                    "text": "Found in Acid Caverns, Carcass, Core, Malformation, Phantasmagoria, The Rotting Core, Toxic Sewer, Waste Pool."
+                },
+                "Vinia's Token": {
+                    "text": "Found in Core, Malformation, Shrine."
+                },
+                "Void of the Elements": {
+                    "text": "Unconfirmed, speculated to drop from Elder and Uber Elder."
+                },
+                "Volatile Power": {
+                    "text": "Found in Crystal Ore, Dig, Excavation, Flooded Mine, Geode, Grotto, The Crystal Veins, The Mines Level 1, The Mines Level 2, The Quarry, The Tunnel."
+                },
+                "Wealth and Power": {
+                    "text": "Found in Cold River, Moon Temple."
+                },
+                "Winter's Embrace": {
+                    "text": "Unconfirmed drop location."
+                }	
 			}
 		},
 		"Fragment": {


### PR DESCRIPTION
- All information from the wiki (https://www.poewiki.net/wiki/List_of_divination_cards).
- Maelström of Chaos references contain the special char, unsure if this problematic?
- Unconfirmed / speculated drop locations have been included.
- Attempted to re-order boss drop locations by Act (Campaign) locations > Map locations, but may not have caught them all.