### PR TITLE
Typo: Update bonusItemInfo.json - Statis Prison Text

### DIFF
--- a/bonusItemInfo.json
+++ b/bonusItemInfo.json
@@ -3604,7 +3604,7 @@
 							"priority": -9
 						},
 						"Stasis Prison": {
-							"text": "Drops from the Unrelenging Timeless Emblem.",
+							"text": "Drops from the Unrelenting Timeless Emblem.",
 							"priority": -5
 						}
 					}


### PR DESCRIPTION
Changing spelling of "Unrelenging" to "Unrelenting" in the Carnal Armour Boss-Drop unique info.